### PR TITLE
'ツイート画面が2つ出てくる現象を修正'

### DIFF
--- a/ac-predictor/ac-predictor.js
+++ b/ac-predictor/ac-predictor.js
@@ -140,11 +140,9 @@ $(window).resize(function () {
 	color: #DDD;
 }
 </style>`
-	var tweetScript =
-`<script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script>`
 	var ratingScript = 
 `<script src="https://koba-e964.github.io/atcoder-rating-estimator/atcoder_rating.js"></script>`
-	$('#main-div').append(`<div id="menu_wrap"><div id="sidemenu" class="container"></div><div id="sidemenu-key" class="glyphicon glyphicon-menu-left"></div>${tweetScript}${ratingScript}${sideMenuScript}${sideMenuStyle}</div>`)
+	$('#main-div').append(`<div id="menu_wrap"><div id="sidemenu" class="container"></div><div id="sidemenu-key" class="glyphicon glyphicon-menu-left"></div>${ratingScript}${sideMenuScript}${sideMenuStyle}</div>`)
 }
 function appendToSideMenu(elem) {
 	$('#sidemenu').append(elem)


### PR DESCRIPTION
`platform.twitter.com/widgets.js`と`twitter.com/intent/tweet`が重複しているとツイートボタンを押したときにツイート画面が2つ開いてしまうことがあるらしいです(→[参考](http://did2memo.net/2013/02/18/return-false-href-2-windows/))(なぜかAtCoder_Result_Tweet_Buttonでは不具合は発生していませんが)
`widgets.js`を読み込んでいる`var tweetScript`を削除しました
問題なければmergeお願いします