### PR TITLE
起動のタイミングによっては順位表で動作しない問題を修正

### DIFF
--- a/addon/src/view/standingsloading.ts
+++ b/addon/src/view/standingsloading.ts
@@ -9,16 +9,25 @@ export default class StandingsLoadingView {
     this.initHandler();
   }
   onLoad(hook: () => void): void {
-    this.hooks.push(hook);
+    if (this.loaded) {
+      hook();
+    } else {
+      this.hooks.push(hook);
+    }
   }
   private initHandler() {
-    new MutationObserver(() => {
+    const execute = () => {
       if (!this.loaded) {
         if (document.getElementById("standings-tbody") === null) return;
         this.loaded = true;
         this.hooks.forEach(f => f());
       }
-    }).observe(this.element, { attributes: true });    
+    };
+    if (this.element.style.display === "none") {
+      execute();
+    } else {
+      new MutationObserver(execute).observe(this.element, { attributes: true });
+    }
   }
 
   static Get() {


### PR DESCRIPTION
詳しくはatcoder-standings-difficulty-analyzerの[issue](https://github.com/iilj/atcoder-standings-difficulty-analyzer/issues/12 )を見ていただきたいのですが、ac-predictorの起動時にすでに順位表が読み込まれていると、StandingsLoadingViewのMutationObserverが発火しないまま待機し続けてしまい、パフォ推測機能が動作しなくなるようです。

atcoder-standings-difficulty-analyzerはiiljさんが直していただいたのですが、今後他の拡張機能の影響を受けたりすることでこのような状況になる可能性もあると思い、念のため修正しておきました。